### PR TITLE
Fix peerDependencies on npm 3+

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   "peerDependencies": {
     "vue-template-compiler": "*"
   },
+  "devDependencies": {
+    "vue-template-compiler": "*"
+  },
   "dependencies": {
     "vue-loader": ">=9.4.2"
   }


### PR DESCRIPTION
Fix Error: 

    Cannot find module 'vue-template-compiler'.